### PR TITLE
Add detach-on-fork information for gdb

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,8 @@ When you use **gdb** to debug a binary with `fork()` function, you can use the f
 * `set follow-fork-mode parent`
 * `set follow-fork-mode child`
 
+Alternatively, using `set detach-on-fork off`, we can then control both sides of each fork. Using `inferior X` where `X` is any of the numbers that show up for `info inferiors` will switch to that side of the fork. This is useful if both sides of the fork are necessary to attack a challenge, and the simple `follow` ones above aren't sufficient.
+
 ## Secret of a mysterious section - .tls
 
 **constraints**:


### PR DESCRIPTION
It is useful in situations when just a simple follow isn't sufficient.

Works something like this:
```
(gdb) info inferiors 
  Num  Description       Executable        
* 1    process 7059      /tmp/tmp.54gc2goeKm/a 
  2    process 7063      /tmp/tmp.54gc2goeKm/a 
(gdb) inferior 2
[Switching to inferior 2 [process 7063] (/tmp/tmp.54gc2goeKm/a)]
[Switching to thread 2.1 (process 7063)]
```