### PR TITLE
add leakable memcpy

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Assume that there is another buffer: `char buf2[60]`
     * Therefore, it may happen overflow.
     * **pwnable**
 
-* `strncpy(buf, buf2, 40)`
+* `strncpy(buf, buf2, 40)` && `memcpy(buf, buf2, 40)`
     * It copies 40 bytes from buf2 to buf, but it won't put NULL byte at the end.
     * Since there is no NULL byte to terminate, it may have **information leak**.
     * **leakable**


### PR DESCRIPTION
```bash
CTF-pwn-tips [master●] bat ./test.c
───────┬─────────────────────────────────────────────────────────────────────────────────
       │ File: ./test.c
───────┼─────────────────────────────────────────────────────────────────────────────────
   1   │ #include <stdio.h>
   2   │ #include <unistd.h>
   3   │ #include <string.h>
   4   │ 
   5   │ int main()
   6   │ {
   7   │        char buf[40];
   8   │        char buf1[60] = "1234567890abcdefghijklmnopqrstuvwxyz";
   9   │        write(1, buf, 40);
  10   │        printf("\n");
  11   │        memcpy(buf, buf1, 20); // leakable
  12   │        write(1, buf, 40);
  13   │        printf("\n");
  14   │        return 0;
  15   │ }
───────┴─────────────────────────────────────────────────────────────────────────────────
CTF-pwn-tips [master●] gcc test.c -o test
CTF-pwn-tips [master●] ./test 
����@2�cvUp0�cvU��&N�
1234567890abcdefghijvUp0�cvU��&N�

```